### PR TITLE
Use env vars for DB config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+POSTGRES_USER=copytrello
+POSTGRES_PASSWORD=copytrello2024
+POSTGRES_DB=copytrello_db
+
+DB_URL=jdbc:postgresql://postgresql:5432/copytrello_db
+DB_USERNAME=copytrello
+DB_PASSWORD=copytrello2024
+
+JWT_SECRET_KEY=yourJwtSecretKey
+MAILjET_API_KEY=yourMailjetApiKey
+MAILjET_SECRET_KEY=yourMailjetSecretKey

--- a/README.md
+++ b/README.md
@@ -33,16 +33,21 @@ Copytrello is a multi-user task planner that provides user registration and auth
 
 3. Ensure that Docker is installed.
 
-4. In the root of the project, create a `.env` file and configure the environment variables for connecting to the database and API keys for Mailjet:
+4. In the root of the project, copy `.env.example` to `.env` and configure the database credentials and Mailjet API keys:
 
     ```plaintext
     POSTGRES_USER=yourPostgresUser
     POSTGRES_PASSWORD=yourPostgresPassword
     POSTGRES_DB=yourPostgresDbName
 
+    # application connection settings
+    DB_URL=jdbc:postgresql://postgresql:5432/copytrello_db
+    DB_USERNAME=yourPostgresUser
+    DB_PASSWORD=yourPostgresPassword
+
     JWT_SECRET_KEY=yourJwtSecretKey
-    COPYTRELLO_MAILJET_API_KEY=yourMailjetApiKey
-    COPYTRELLO_MAILJET_SECRET_KEY=yourMailjetSecretKey
+    MAILjET_API_KEY=yourMailjetApiKey
+    MAILjET_SECRET_KEY=yourMailjetSecretKey
     ```
 
     To obtain Mailjet keys, register on the official [Mailjet website](https://www.mailjet.com/). Go to the API section and generate a SECRET KEY. Also, in the email-sender configuration file, replace the email address with the one you registered with Mailjet.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,9 +64,9 @@ services:
       - '8300:8300'
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgresql:5432/copytrello_db
-      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
-      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+      DB_URL: jdbc:postgresql://postgresql:5432/copytrello_db
+      DB_USERNAME: ${POSTGRES_USER}
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
       JWT_KEY: ${JWT_SECRET_KEY}
     volumes:
       - ./logs/backend:/logs
@@ -86,9 +86,9 @@ services:
       - "5005:5005"
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgresql:5432/copytrello_db
-      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
-      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+      DB_URL: jdbc:postgresql://postgresql:5432/copytrello_db
+      DB_USERNAME: ${POSTGRES_USER}
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
       JAVA_TOOL_OPTIONS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
     volumes:
       - ./logs/scheduler:/logs

--- a/task-tracker-backend/src/main/resources/application.yml
+++ b/task-tracker-backend/src/main/resources/application.yml
@@ -5,9 +5,9 @@ spring:
     name: copytrello
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://dpg-ctmjg352ng1s73bcpoj0-a/copytrello_db
-    username: copytrello_db_user
-    password: xm9I5M5NpCl7LXGHiPwLq9ymXeN8AjQJ
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: update

--- a/task-tracker-scheduler/src/main/resources/application.yml
+++ b/task-tracker-scheduler/src/main/resources/application.yml
@@ -2,8 +2,9 @@ spring:
   application:
     name: task-tracker-scheduler
   datasource:
-    url: jdbc:postgresql://localhost:5431/copytrello_db
-    password: ${POSTGRES_PASSWORD}
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 server:
   port: 8880
 scheduling:


### PR DESCRIPTION
## Summary
- switch backend and scheduler configs to read `DB_URL`, `DB_USERNAME`, and `DB_PASSWORD`
- provide these values in `docker-compose.yml`
- add sample `.env.example`
- update README with the new environment variables

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685263eb45908328b0fcdaddd610628a