### PR TITLE
Fix insecure logging in AuthController

### DIFF
--- a/task-tracker-backend/src/main/java/com/repinsky/task_tracker_backend/controllers/AuthController.java
+++ b/task-tracker-backend/src/main/java/com/repinsky/task_tracker_backend/controllers/AuthController.java
@@ -44,7 +44,7 @@ public class AuthController {
 
     @PostMapping("/register")
     public ResponseEntity<?> registerNewUser(@RequestBody RegisterUserRequest registerUserRequest) throws InputDataException {
-        log.info("Request to create new user: email -> {}, password -> {}, confirmedPassword -> {}", registerUserRequest.getEmail(), registerUserRequest.getPassword(), registerUserRequest.getConfirmPassword());
+        log.info("Request to create new user: email -> {}", registerUserRequest.getEmail());
         userService.createNewUser(registerUserRequest);
         return ResponseEntity.ok(new StringResponse("User with email '" + registerUserRequest.getEmail() + "' registered successfully"));
     }


### PR DESCRIPTION
## Summary
- avoid logging passwords on user registration

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685263efff7c832889ad96c88843fba2